### PR TITLE
Upgrade to Hyper 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,16 @@
 name = "spellbook"
 version = "0.1.0"
 authors = ["Cameron Paul <cpaul37@gmail.com>"]
+edition = "2021"
 
 [dependencies]
+bytes = "1"
 futures = "*"
-hyper = "*"
+http-body-util = "0.1.0-rc.2"
+hyper = { version = "1.0.0-rc.3", features = ["full"] }
 serde = "*"
 serde_urlencoded = "*"
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 serde_derive = "*"

--- a/src/router/tree.rs
+++ b/src/router/tree.rs
@@ -1,4 +1,4 @@
-use Handler;
+use crate::Handler;
 
 use std::collections::HashMap;
 
@@ -16,9 +16,7 @@ pub struct Tree<S: Clone> {
 
 impl<S: Clone> Tree<S> {
     pub fn new() -> Tree<S> {
-        let mut tree = Tree {
-            nodes: vec![],
-        };
+        let mut tree = Tree { nodes: vec![] };
 
         tree.node_new();
 


### PR DESCRIPTION
Upgrade to Hyper 1.0. This builds and runs with the following example:

```rust
use spellbook::{Context, Response, Router, Server};

#[derive(Clone)]
struct State {
    title: &'static str,
}

fn welcome_handler(context: Context<State>) -> spellbook::Result {
    let body = format!("<h1>Welcome to {}</h1>", context.state.title);
    Ok(Response::builder().body(body)?)
}

fn main() -> std::io::Result<()> {
    let state = State { title: "My App" };

    let address = ([127, 0, 0, 1], 3000).into();
    let router = Router::new().get("/", welcome_handler);

    Server::new(state, router).serve(address)?;

    Ok(())
}
```

From the library consumer's perspective, the biggest thing that needs changing for this PR is making handlers async, so `welcome_handler` should look like this:

```rust
async fn welcome_handler(context: Context<State>) -> spellbook::Result {
    let body = format!("<h1>Welcome to {}</h1>", context.state.title);
    Ok(Response::builder().body(body)?)
}
```

There are several other outstanding TODOs that need to be addressed as part of this PR:

- [ ] Make handlers be async
- [ ] Make custom body type so we can construct Requests for tests. The current `hyper::body::Incoming` struct can't be created by us.
- [ ] Fix tests
- [ ] Cleanup and pin dependencies
- [ ] Update docs

And one other TODO that isn't required but would make sense to do in this PR while all the types are being updated anyway:
- [ ] Make handlers take &Context or Rc<Context> and don't require State implement Clone. The point here being that Context shouldn't need to be cloned unless it's being modified.